### PR TITLE
Add S3io::ReadWrapper#gets

### DIFF
--- a/lib/s3io/read_wrapper.rb
+++ b/lib/s3io/read_wrapper.rb
@@ -82,5 +82,13 @@ module S3io
     alias lines each
     alias each_line each
 
+    # @param [String] separator line separator string
+    def gets(separator = $/)
+      @_gets ||= enum_for(:each, separator)
+      @_gets.next
+    rescue StopIteration
+      nil
+    end
+
   end
 end

--- a/test/test_s3io_read_wrapper.rb
+++ b/test/test_s3io_read_wrapper.rb
@@ -142,4 +142,15 @@ class S3ioReadWrapperTest < Test::Unit::TestCase
 
     assert_equal('', wrapper.read)
   end
+
+  def test_gets
+    wrapper = S3io::ReadWrapper.new(@s3object)
+
+    lines = []
+    while line = wrapper.gets
+      lines << line
+    end
+
+    assert_equal(S3_TEST_DATA.lines.to_a, lines)
+  end
 end


### PR DESCRIPTION
In my code I needed http://ruby-doc.org/core-2.0.0/IO.html#method-i-gets supported by IO object. The added code doesn't support all features native `gets` does but could be still probably useful